### PR TITLE
Update create-deploy-retrain-machine-learning-model.md

### DIFF
--- a/create-deploy-retrain-machine-learning-model.md
+++ b/create-deploy-retrain-machine-learning-model.md
@@ -328,4 +328,4 @@ In this section, you will evaluate the model by uploading a `iris_retrain.csv` f
 - [{{site.data.keyword.cpd_full_notm}} Overview](https://dataplatform.{DomainName}/docs/content/wsj/getting-started/welcome-main.html?context=analytics)
 - [Automatic model creation](https://dataplatform.{DomainName}/docs/content/wsj/analyze-data/autoai-overview.html?context=analytics)
 - [Machine learning & AI](https://dataplatform.{DomainName}/docs/content/wsj/analyze-data/wml-ai.html?context=analytics)
-- [{{site.data.keyword.aios_short}} documentation](https://{DomainName}/docs/ai-openscale)
+- [{{site.data.keyword.aios_short}} documentation](https://dataplatform.{DomainName}/docs/content/wsj/model/getting-started.html?context=analytics)


### PR DESCRIPTION
Updating URL for OpenScale documentation, which has moved to the Watson Studio doc hub.