### PR TITLE
Update vpc-bm-vmware-bms.md

### DIFF
--- a/vpc-bm-vmware-bms.md
+++ b/vpc-bm-vmware-bms.md
@@ -229,19 +229,19 @@ The used variables e.g. $VMWARE_VPC_ZONE, $VMWARE_SUBNET_HOST and $VMWARE_DNS_ZO
 1. Get the IP addresses of the servers and record them for future use into a variable.
 
    ```sh
-   VMWARE_BMS001_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS001 -output json | jq -r '.primary_network_interface.primary_ipv4_address')
+   VMWARE_BMS001_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS001 -output json | jq -r '.primary_network_interface.primary_ip.address')
    echo "VMWARE_BMS001 IP : "$VMWARE_BMS001_MGMT_IP
    ```
    {: codeblock}
 
    ```sh
-   VMWARE_BMS002_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS002 -output json | jq -r '.primary_network_interface.primary_ipv4_address')
+   VMWARE_BMS002_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS002 -output json | jq -r '.primary_network_interface.primary_ip.address')
    echo "VMWARE_BMS002 IP : "$VMWARE_BMS002_MGMT_IP
    ```
    {: codeblock}
 
    ```sh
-   VMWARE_BMS003_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS003 -output json | jq -r '.primary_network_interface.primary_ipv4_address')
+   VMWARE_BMS003_MGMT_IP=$(ibmcloud is bm $VMWARE_BMS003 -output json | jq -r '.primary_network_interface.primary_ip.address')
    echo "VMWARE_BMS003 IP : "$VMWARE_BMS003_MGMT_IP
    ```
    {: codeblock}
@@ -370,21 +370,21 @@ Instance management VLAN NICs e.g. for vCenter will be created later.
 
    ```sh
    VMWARE_BMS001_VMOT=$(ibmcloud is bm-nicc $VMWARE_BMS001 --subnet $VMWARE_SUBNET_VMOT --name vlan-nic-vmotion-vmk2 --interface-type vlan --vlan 200 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS001_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS001 $VMWARE_BMS001_VMOT --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS001_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS001 $VMWARE_BMS001_VMOT --output json | jq -r .primary_ip.address)
    echo "vMotion IP for BMS001 : "$VMWARE_BMS001_VMOT_IP
    ```
    {: codeblock}
 
    ```sh
    VMWARE_BMS002_VMOT=$(ibmcloud is bm-nicc $VMWARE_BMS002 --subnet $VMWARE_SUBNET_VMOT --name vlan-nic-vmotion-vmk2 --interface-type vlan --vlan 200 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS002_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS002 $VMWARE_BMS002_VMOT --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS002_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS002 $VMWARE_BMS002_VMOT --output json | jq -r .primary_ip.address)
    echo "vMotion IP for BMS002 : "$VMWARE_BMS002_VMOT_IP
    ```
    {: codeblock}
 
    ```sh
    VMWARE_BMS003_VMOT=$(ibmcloud is bm-nicc $VMWARE_BMS003 --subnet $VMWARE_SUBNET_VMOT --name vlan-nic-vmotion-vmk2 --interface-type vlan --vlan 200 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS003_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS003 $VMWARE_BMS003_VMOT --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS003_VMOT_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS003 $VMWARE_BMS003_VMOT --output json | jq -r .primary_ip.address)
    echo "vMotion IP for BMS003 : "$VMWARE_BMS003_VMOT_IP
    ```
    {: codeblock}
@@ -410,21 +410,21 @@ This phase is optional, if you use NFS.
 
    ```sh
    VMWARE_BMS001_VSAN=$(ibmcloud is bm-nicc $VMWARE_BMS001 --subnet $VMWARE_SUBNET_VSAN --name vlan-nic-vsan-vmk3 --interface-type vlan --vlan 300 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS001_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS001 $VMWARE_BMS001_VSAN --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS001_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS001 $VMWARE_BMS001_VSAN --output json | jq -r .primary_ip.address)
    echo "vSAN IP for BMS001 : "$VMWARE_BMS001_VSAN_IP
    ```
    {: codeblock}
 
    ```sh
    VMWARE_BMS002_VSAN=$(ibmcloud is bm-nicc $VMWARE_BMS002 --subnet $VMWARE_SUBNET_VSAN --name vlan-nic-vsan-vmk3 --interface-type vlan --vlan 300 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS002_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS002 $VMWARE_BMS002_VSAN --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS002_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS002 $VMWARE_BMS002_VSAN --output json | jq -r .primary_ip.address)
    echo "vSAN IP for BMS002 : "$VMWARE_BMS002_VSAN_IP
    ```
    {: codeblock}
 
    ```sh
    VMWARE_BMS003_VSAN=$(ibmcloud is bm-nicc $VMWARE_BMS003 --subnet $VMWARE_SUBNET_VSAN --name vlan-nic-vsan-vmk3 --interface-type vlan --vlan 300 --allow-interface-to-float false --output json | jq -r .id)
-   VMWARE_BMS003_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS003 $VMWARE_BMS003_VSAN --output json | jq -r .primary_ipv4_address)
+   VMWARE_BMS003_VSAN_IP=$(ibmcloud is bare-metal-server-network-interface $VMWARE_BMS003 $VMWARE_BMS003_VSAN --output json | jq -r .primary_ip.address)
    echo "vSAN IP for BMS003 : "$VMWARE_BMS003_VSAN_IP
    ```
    {: codeblock}


### PR DESCRIPTION
Hello! 
I was following the tutorial and I noticed that in some commands the mentioned object primary_ipv4_address doesn't work on the current version of the cli. After some testing, I learned that it works on `primary_ip.address`, so I changed 'primary_ipv4_address' to 'primary_ip.address' in this pull request.

Please find below an example of the JSON object for this section when running the command `ibmcloud is bm $VMWARE_BMS001 -output json | grep primary -c 10`

```
 "primary_network_interface": {
        "floating_ips": null,
        "href": "https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/----------------",
        "id": "0717------------------ae3af3521ea4",
        "name": "pci-nic-vmnic0-vmk0",
        "primary_ip": {
            "address": "10.X.X.4",
            "href": "https://us-south.iaas.cloud.ibm.com/v1/subnets/----------",
            "id": "0717-------------------ab",
            "name": "smashup-quitter-limes-galore",
            "resource_type": "subnet_reserved_ip"
        },
```

when running the command `ibmcloud is bm $VMWARE_BMS001 -output json | jq -r '.primary_network_interface.primary_ip.address'` I get the correct output with the primary IP address